### PR TITLE
deployコマンドをlocal-onlyに変更

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --local-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
`flyctl deploy`には`--remote-only`と`--local-only`がある。
色々と試している際にリモートでのビルドがうまくいかなかったことがあったため`--local-only`に変更してみる。